### PR TITLE
Add translations for Portuguese and its Brazilian variant

### DIFF
--- a/lang/pt-br/lang.php
+++ b/lang/pt-br/lang.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * English language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ */
+
+// custom language strings for the plugin
+
+$lang['yearbox_months'] = ['Jan', 'Fev', 'Mar', 'Abr', 'Pos', 'Jun',
+                                'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
+// week begins on Sunday in PHP...
+$lang['yearbox_days'] = 'DSTQQSS';

--- a/lang/pt/lang.php
+++ b/lang/pt/lang.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * English language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ */
+
+// custom language strings for the plugin
+
+$lang['yearbox_months'] = ['Jan', 'Fev', 'Mar', 'Abr', 'Pos', 'Jun',
+                                'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
+// week begins on Sunday in PHP...
+$lang['yearbox_days'] = 'DSTQQSS';


### PR DESCRIPTION
They are from google translate. Also, google translate doesn't
differentiate between the Portuguese of Portugal and that of Brazil.
I'll hope they are the same.