### PR TITLE
automate releases more

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,12 @@
+name: Lint Commit Messages
+on: [ pull_request ]
+
+jobs:
+    commitlint:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+            -   uses: wagoid/commitlint-github-action@v2

--- a/.versionrc.js
+++ b/.versionrc.js
@@ -1,0 +1,9 @@
+// .versionrc.js
+const tracker = {
+    filename: 'plugin.info.txt',
+    updater: require('./build/pluginInfoVersionUpdater')
+};
+
+module.exports = {
+    bumpFiles: [tracker],
+};

--- a/build/pluginInfoVersionUpdater.js
+++ b/build/pluginInfoVersionUpdater.js
@@ -1,0 +1,23 @@
+module.exports = {
+    readVersion( contents ) {
+        return ''; // The plugin.info.txt does not contain a semantic version
+    },
+
+    writeVersion( contents ) {
+        const options = contents
+            .trim()
+            .split("\n")
+            .map(line => {
+                const indexOfFirstSpace = line.indexOf(' ');
+                return [line.slice(0, indexOfFirstSpace), line.slice(indexOfFirstSpace + 1)]
+                    .map( piece => piece.trim()) })
+            .reduce( (carry, [key, value]) => { return { ...carry, [key]: value};}, {} );
+
+        options.date = (new Date()).toISOString().substr(0, 10);
+
+        const longestKey = Object.keys(options).reduce( (carry, key) => Math.max(carry, key.length), 0);
+        return Object.entries(options)
+            .map( ([key, value]) => key.padEnd(longestKey) + ' ' + value)
+            .join("\n");
+    },
+};


### PR DESCRIPTION
This asserts the commit message of commits in pull requests and adds a config file for doing releases with [conventional-changelog/standard-version](https://github.com/conventional-changelog/standard-version)